### PR TITLE
Update chrome-admin-menu-fix.php

### DIFF
--- a/chrome-admin-menu-fix.php
+++ b/chrome-admin-menu-fix.php
@@ -13,5 +13,3 @@ function chromefix_inline_css()
 }
 
 add_action('admin_enqueue_scripts', 'chromefix_inline_css');
-
-?>


### PR DESCRIPTION
removed obsolete ?> from file end.
